### PR TITLE
feat: add OpenAI organization option

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -7,6 +7,11 @@ program
     process.env.OPENAI_API_KEY
   )
   .option(
+    '--organization [key]',
+    'OpenAI organization ID',
+    process.env.OPENAI_ORGANIZATION
+  )
+  .option(
     '--baseUrl [url]',
     'OpenAI base url which can be change for other use'
   )
@@ -24,6 +29,7 @@ program
 
 export const options = program.opts<{
   apiKey?: string;
+  organization?: string;
   baseUrl?: string;
   model: string;
   project: string;

--- a/src/translate.ts
+++ b/src/translate.ts
@@ -5,6 +5,7 @@ export async function translate(content: string, targetLanguage: string) {
   const client = new OpenAI({
     baseURL: options.baseUrl,
     apiKey: options.apiKey,
+    organization: options.organization,
   });
 
   const chatCompletion = await client.chat.completions.create({


### PR DESCRIPTION
Thank you for this awesome open-source project!

I work for a company that requires specifying an organization ID when using the OpenAI API. To address this, this pull request introduces the ability to specify an OpenAI organization ID.

I'd appreciate your consideration of this addition. Please let me know if you need any clarification or if there are any changes you'd like me to make.